### PR TITLE
Remove reference from .zshrc.local

### DIFF
--- a/mac
+++ b/mac
@@ -14,11 +14,7 @@ append_to_zshrc() {
   local text="$1" zshrc
   local skip_new_line="${2:-0}"
 
-  if [ -w "$HOME/.zshrc.local" ]; then
-    zshrc="$HOME/.zshrc.local"
-  else
-    zshrc="$HOME/.zshrc"
-  fi
+  zshrc="$HOME/.zshrc"
 
   if ! grep -Fqs "$text" "$zshrc"; then
     if [ "$skip_new_line" -eq 1 ]; then


### PR DESCRIPTION
No one will have a .zshrc.local setup on a clean install, and this is handled in our
dotfiles, so let's remove this reference.